### PR TITLE
fix: respect sortType parameter

### DIFF
--- a/src/main/java/com/cnpm/bottomcv/service/impl/ProfileServiceImpl.java
+++ b/src/main/java/com/cnpm/bottomcv/service/impl/ProfileServiceImpl.java
@@ -27,8 +27,8 @@ public class ProfileServiceImpl implements ProfileService {
 
     @Override
     public ListResponse<ProfileResponse> allProfiles(int pageNo, int pageSize, String sortBy, String sortType) {
-        Sort sortObj = sortBy.equalsIgnoreCase(Sort.Direction.ASC.name()) ? Sort.by(sortBy).ascending()
-                : Sort.by(sortBy).descending();
+        Sort sortObj = sortType.equalsIgnoreCase(Sort.Direction.ASC.name()) ?
+                Sort.by(sortBy).ascending() : Sort.by(sortBy).descending();
         Pageable pageable = PageRequest.of(pageNo, pageSize, sortObj);
         Page<Profile> pageProfiles = profileRepository.findAll(pageable);
         List<Profile> profiles = pageProfiles.getContent();

--- a/src/test/java/com/cnpm/bottomcv/service/ProfileServiceImplTest.java
+++ b/src/test/java/com/cnpm/bottomcv/service/ProfileServiceImplTest.java
@@ -1,0 +1,46 @@
+package com.cnpm.bottomcv.service;
+
+import com.cnpm.bottomcv.model.Profile;
+import com.cnpm.bottomcv.repository.ProfileRepository;
+import com.cnpm.bottomcv.service.impl.ProfileServiceImpl;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ProfileServiceImplTest {
+
+    @Mock
+    private ProfileRepository profileRepository;
+
+    @InjectMocks
+    private ProfileServiceImpl profileService;
+
+    @Test
+    void allProfiles_usesSortTypeParameter() {
+        Page<Profile> page = new PageImpl<>(Collections.emptyList());
+        when(profileRepository.findAll(any(Pageable.class))).thenReturn(page);
+
+        profileService.allProfiles(0, 10, "id", "ASC");
+
+        ArgumentCaptor<Pageable> captor = ArgumentCaptor.forClass(Pageable.class);
+        verify(profileRepository).findAll(captor.capture());
+        Pageable pageable = captor.getValue();
+
+        assertEquals(Sort.by("id").ascending(), pageable.getSort());
+    }
+}


### PR DESCRIPTION
## Summary
- use the provided sort type when ordering profiles
- add unit test for profile sort direction

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689cb4149a50832aac8e9717898a514b