### PR TITLE
feat: apply rbac to company api

### DIFF
--- a/src/main/java/com/cnpm/bottomcv/controller/CompanyController.java
+++ b/src/main/java/com/cnpm/bottomcv/controller/CompanyController.java
@@ -55,21 +55,25 @@ public class CompanyController {
             @RequestParam(defaultValue = "10") int pageSize,
             @RequestParam(defaultValue = "id") String sortBy,
             @RequestParam(defaultValue = "asc") String sortType) {
-        return ResponseEntity.ok(companyService.getAllCompanies(pageNo, pageSize, sortBy, sortType));
+        return ResponseEntity.ok(
+                companyService.getAllCompanies(pageNo, pageSize, sortBy, sortType));
     }
 
     // Front APIs (for client web - public)
     @GetMapping("/front/companies/{id}")
+    @PreAuthorize("hasAnyRole('CANDIDATE', 'EMPLOYER', 'ADMIN')")
     public ResponseEntity<CompanyResponse> getCompanyByIdForFront(@PathVariable Long id) {
         return ResponseEntity.ok(companyService.getCompanyById(id));
     }
 
     @GetMapping("/front/companies")
+    @PreAuthorize("hasAnyRole('CANDIDATE', 'EMPLOYER', 'ADMIN')")
     public ResponseEntity<ListResponse<CompanyResponse>> getAllCompaniesForFront(
             @RequestParam(defaultValue = "0") int pageNo,
             @RequestParam(defaultValue = "10") int pageSize,
             @RequestParam(defaultValue = "id") String sortBy,
             @RequestParam(defaultValue = "asc") String sortType) {
-        return ResponseEntity.ok(companyService.getAllCompanies(pageNo, pageSize, sortBy, sortType));
+        return ResponseEntity.ok(
+                companyService.getAllCompanies(pageNo, pageSize, sortBy, sortType));
     }
 }

--- a/src/main/java/com/cnpm/bottomcv/service/CompanyService.java
+++ b/src/main/java/com/cnpm/bottomcv/service/CompanyService.java
@@ -3,11 +3,14 @@ package com.cnpm.bottomcv.service;
 import com.cnpm.bottomcv.dto.request.CompanyRequest;
 import com.cnpm.bottomcv.dto.response.CompanyResponse;
 import com.cnpm.bottomcv.dto.response.ListResponse;
-
 public interface CompanyService {
     CompanyResponse createCompany(CompanyRequest request);
+
     CompanyResponse updateCompany(Long id, CompanyRequest request);
+
     void deleteCompany(Long id);
+
     ListResponse<CompanyResponse> getAllCompanies(int pageNo, int pageSize, String sortBy, String sortType);
+
     CompanyResponse getCompanyById(Long id);
 }

--- a/src/main/java/com/cnpm/bottomcv/service/impl/CompanyServiceImpl.java
+++ b/src/main/java/com/cnpm/bottomcv/service/impl/CompanyServiceImpl.java
@@ -17,6 +17,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -39,7 +41,8 @@ public class CompanyServiceImpl implements CompanyService {
         mapRequestToEntity(company, request);
 
         company.setCreatedAt(LocalDateTime.now());
-        company.setCreatedBy("system");
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        company.setCreatedBy(auth != null ? auth.getName() : "system");
 
         companyRepository.save(company);
         return mapToResponse(company);
@@ -54,7 +57,7 @@ public class CompanyServiceImpl implements CompanyService {
 
     @Override
     public ListResponse<CompanyResponse> getAllCompanies(int pageNo, int pageSize, String sortBy, String sortType) {
-        Sort sortObj = sortBy.equalsIgnoreCase(Sort.Direction.ASC.name()) ? Sort.by(sortBy).ascending() : Sort.by(sortBy).descending();
+        Sort sortObj = sortType.equalsIgnoreCase("ASC") ? Sort.by(sortBy).ascending() : Sort.by(sortBy).descending();
         Pageable pageable = PageRequest.of(pageNo, pageSize, sortObj);
         Page<Company> pageCompany = companyRepository.findAll(pageable);
         List<Company> companyContent = pageCompany.getContent();
@@ -81,7 +84,8 @@ public class CompanyServiceImpl implements CompanyService {
         mapRequestToEntity(company, request);
 
         company.setUpdatedAt(LocalDateTime.now());
-        company.setUpdatedBy("system");
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        company.setUpdatedBy(auth != null ? auth.getName() : "system");
 
         companyRepository.save(company);
         return mapToResponse(company);


### PR DESCRIPTION
## Summary
- expose CompanyService methods without passing Authentication and rely on controller-level RBAC
- populate audit fields using the current principal via SecurityContextHolder
- fix company listing sort direction to respect provided sortType

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689cb7e40618832a8b92d225b8eaae73